### PR TITLE
feat: support RDT_CONFIG_DIR and XDG_CONFIG_HOME for config path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ rdt comment 3 "Great post!"           # Comment on result #3
 
 rdt-cli supports browser cookie extraction to authenticate with Reddit:
 
-1. **Saved cookies** — loads from `~/.config/rdt-cli/credential.json`
+1. **Saved cookies** — loads from `~/.config/rdt-cli/credential.json` (see [Environment Variables](#environment-variables) to override the config directory)
 2. **Browser cookies** — auto-detects installed browsers and extracts cookies (supports Chrome, Firefox, Edge, Brave)
 
 `rdt login` automatically tries all installed browsers and uses the first one with valid cookies.
@@ -149,6 +149,8 @@ After any listing command such as `feed`, `popular`, `all`, `sub`, or `search`, 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OUTPUT` | `auto` | Output format: `json`, `yaml`, `rich`, or `auto` (→ YAML when non-TTY) |
+| `RDT_CONFIG_DIR` | *(unset)* | Override the config directory entirely. Takes priority over `XDG_CONFIG_HOME` and the default path. Useful when running multiple isolated instances that must not share credentials. |
+| `XDG_CONFIG_HOME` | *(unset)* | If set, rdt-cli stores its config under `$XDG_CONFIG_HOME/rdt-cli` per the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/). Ignored when `RDT_CONFIG_DIR` is set. |
 
 ## Rate Limiting & Anti-Detection
 

--- a/rdt_cli/constants.py
+++ b/rdt_cli/constants.py
@@ -1,9 +1,26 @@
 """Constants for Reddit CLI — API endpoints, headers, and config paths."""
 
+import os
 from pathlib import Path
 
+
 # ── Config ──────────────────────────────────────────────────────────
-CONFIG_DIR = Path.home() / ".config" / "rdt-cli"
+def _resolve_config_dir() -> Path:
+    """Resolve config directory with the following priority:
+
+    1. ``RDT_CONFIG_DIR`` env var — explicit override (useful for isolated or
+       multi-user environments where multiple instances must not share config).
+    2. ``XDG_CONFIG_HOME/rdt-cli`` — XDG Base Directory spec (Linux/macOS).
+    3. ``~/.config/rdt-cli`` — historical default, always available as fallback.
+    """
+    if rdt_dir := os.environ.get("RDT_CONFIG_DIR"):
+        return Path(rdt_dir)
+    if xdg_home := os.environ.get("XDG_CONFIG_HOME"):
+        return Path(xdg_home) / "rdt-cli"
+    return Path.home() / ".config" / "rdt-cli"
+
+
+CONFIG_DIR = _resolve_config_dir()
 CREDENTIAL_FILE = CONFIG_DIR / "credential.json"
 
 # ── Base URL ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The config directory is currently hardcoded to `~/.config/rdt-cli`:

```python
CONFIG_DIR = Path.home() / ".config" / "rdt-cli"
```

This causes two issues:

1. **Multi-instance isolation** — when multiple independent processes (e.g. automated agents, CI jobs, or per-user instances) run on the same machine, they all read/write the same credential file. This leads to credential collisions and unintended sharing.
2. **XDG non-compliance** — the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/) is the standard way for users to relocate config on Linux/macOS, but rdt-cli ignores `XDG_CONFIG_HOME`.

## Solution

Resolve the config directory using a priority chain with no breaking change:

| Priority | Source | Example |
|----------|--------|---------|
| 1 | `RDT_CONFIG_DIR` env var | `RDT_CONFIG_DIR=/tmp/myagent/rdt` rdt whoami |
| 2 | `XDG_CONFIG_HOME/rdt-cli` | `XDG_CONFIG_HOME=~/.config-work` rdt whoami |
| 3 | `~/.config/rdt-cli` | existing default — unchanged |

The implementation is a small helper function in `constants.py`:

```python
def _resolve_config_dir() -> Path:
    if rdt_dir := os.environ.get("RDT_CONFIG_DIR"):
        return Path(rdt_dir)
    if xdg_home := os.environ.get("XDG_CONFIG_HOME"):
        return Path(xdg_home) / "rdt-cli"
    return Path.home() / ".config" / "rdt-cli"
```

## Changes

- `rdt_cli/constants.py` — introduce `_resolve_config_dir()`, replace the hardcoded path
- `README.md` — document `RDT_CONFIG_DIR` and `XDG_CONFIG_HOME` in the Environment Variables table; link the Authentication section to it

## Backwards compatibility

No breaking change. When neither env var is set, the resolved path is identical to the previous hardcoded value.