### PR TITLE
fix: swap httpx transport for requests to avoid Reddit 403

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "rich>=13.0",
-    "httpx>=0.27",
+    "requests>=2.31",
     "browser-cookie3>=0.19",
     "pyyaml>=6.0",
 ]

--- a/rdt_cli/transports.py
+++ b/rdt_cli/transports.py
@@ -7,7 +7,7 @@ import random
 import time
 from typing import Any
 
-import httpx
+import requests
 
 from .config import RuntimeConfig
 from .constants import BASE_URL
@@ -42,19 +42,19 @@ class BaseTransport:
         self._max_retries = config.max_retries
         self._last_request_time = 0.0
         self._request_count = 0
-        self._http = httpx.Client(
-            base_url=BASE_URL,
-            headers=self.default_headers(),
-            cookies=session.cookies,
-            follow_redirects=True,
-            timeout=httpx.Timeout(config.timeout),
-        )
+        # Use requests.Session instead of httpx.Client: Reddit's bot
+        # detection fingerprints the httpx TLS/HTTP stack and returns
+        # a 403 challenge page, while urllib3/requests passes.
+        self._http = requests.Session()
+        self._http.headers.update(self.default_headers())
+        self._http.cookies.update(session.cookies)
+        self._http.max_redirects = 10
 
     def close(self) -> None:
         self._http.close()
 
     @property
-    def client(self) -> httpx.Client:
+    def client(self) -> requests.Session:
         return self._http
 
     @property
@@ -74,7 +74,7 @@ class BaseTransport:
                 jitter += random.uniform(2.0, 5.0)
             time.sleep(self._request_delay - elapsed + jitter)
 
-    def _merge_response_cookies(self, resp: httpx.Response) -> None:
+    def _merge_response_cookies(self, resp: requests.Response) -> None:
         for name, value in resp.cookies.items():
             if not value:
                 continue
@@ -85,11 +85,13 @@ class BaseTransport:
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         self._rate_limit_delay()
         last_exc: Exception | None = None
+        if url.startswith("/"):
+            url = BASE_URL + url
 
         for attempt in range(self._max_retries):
             t0 = time.time()
             try:
-                resp = self.client.request(method, url, **kwargs)
+                resp = self.client.request(method, url, timeout=self.config.timeout, **kwargs)
                 elapsed = time.time() - t0
                 self._merge_response_cookies(resp)
                 self._request_count += 1
@@ -131,7 +133,7 @@ class BaseTransport:
                 if not text.strip():
                     return {}
                 return resp.json()
-            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            except (requests.Timeout, requests.ConnectionError) as exc:
                 last_exc = exc
                 wait = (2**attempt) + random.uniform(0, 1)
                 logger.warning("Network error: %s, retrying in %.1fs", exc, wait)


### PR DESCRIPTION
## Summary

Reddit's bot detection fingerprints the httpx TLS/HTTP stack and returns a **403 challenge page** even with a valid `reddit_session` cookie. Replacing the `httpx.Client` with a `requests.Session` fixes it — `urllib3`/`requests` passes Reddit's fingerprint checks.

Closes #13 (same repro: valid cookie works with curl/urllib, httpx gets 403).

## Changes

- `rdt_cli/transports.py`:
  - `httpx.Client` → `requests.Session` (headers + cookies copied, `max_redirects=10`)
  - Manual `BASE_URL` joining for relative URLs (`requests` has no `base_url`)
  - Explicit `timeout=self.config.timeout` per request (`requests` has no default)
  - `httpx.TimeoutException/NetworkError` → `requests.Timeout/ConnectionError`
- `pyproject.toml`: `httpx>=0.27` → `requests>=2.31` (httpx no longer imported anywhere)

## Why requests instead of patching httpx?

- The 403 is driven by TLS/HTTP-stack fingerprinting, not headers — tweaking httpx headers alone doesn't reliably pass (see #13's own curl-vs-httpx comparison).
- `requests` is a lighter, ubiquitous dependency already used transitively by most Python stacks.
- This is also what makes rdt-cli work on Termux/Android, where the httpx+brotli stack misbehaves.

## Verification

- ✅ `pytest tests/` → **123 passed** (66 deselected)
- ✅ Live against Reddit with a real session:
  - `GET /r/python/top.json?limit=2` → returns posts (no 403)
  - `GET /api/v1/me` → no 403, no exception